### PR TITLE
:pencil2: Fix typos for mobile no pass page

### DIFF
--- a/src/app/create/create.component.html
+++ b/src/app/create/create.component.html
@@ -25,8 +25,8 @@
 <ng-template #mobileNoPass>
     <div class="mobile-no-pass">
         <img src="./assets/logo.svg">
-        <p class="fs-2">Hey, we are so sorry, but systemizer is currentkly not supported on mobile devices :&nbsp;(</p>
-        <p class="fs-4">But we are workin on optimization for mobile devices.</p>
+        <p class="fs-2">Hey, we are so sorry, but systemizer is currently not supported on mobile devices :&nbsp;(</p>
+        <p class="fs-4">But we are working on optimization for mobile devices.</p>
         <a class="btn-purple" routerLink="/">Go back</a>
     </div>
 </ng-template>


### PR DESCRIPTION
sorry for nitpicking but i don't like typos and need some github karma.
but i noticed that `Hey, we are so sorry, but systemizer is currentkly not supported on mobile devices`  also exists in `docs\main.acc39c47e9f0d88fda7c.js` and i'm not sure why this file exists or what it is so didn't touch it